### PR TITLE
Revert "Bump addressable from 2.6.0 to 2.8.4 in /en"

### DIFF
--- a/en/Gemfile.lock
+++ b/en/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.4)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.5)
     em-websocket (0.5.1)
@@ -49,7 +49,7 @@ GEM
     mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.3)
+    public_suffix (3.0.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)


### PR DESCRIPTION
Reverts plavi-projekt/plavi-projekt.github.io#7